### PR TITLE
fix: adjust z-index and background color for mobile navbar

### DIFF
--- a/venture-connect-frontend/src/Layouts/UserLayout.jsx
+++ b/venture-connect-frontend/src/Layouts/UserLayout.jsx
@@ -37,9 +37,9 @@ const UserLayout = () => {
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <div className="absolute md:hidden bg-slate-300/15 h-min w-full flex justify-end items-center px-2 py-2 shadow-sm">
+      <div className="absolute md:hidden z-30 bg-gray-50 h-min w-full flex justify-end items-center px-2 py-2 shadow-sm">
         <button
-          className="size-fit float-end z-20 bg-gray-200 py-1 px-3 rounded-md hover:ring-1 hover:ring-black"
+          className="size-fit float-end z-0 bg-gray-200 py-1 px-3 rounded-md hover:ring-1 hover:ring-black"
           onClick={toggleSidebar}
         >
           <FontAwesomeIcon icon={faBars} />


### PR DESCRIPTION
Issue:
When scrolling, the cards were appearing on top of the mobile navbar, causing a visual overlap issue.

Solution:
Adjusted the z-index of the mobile navbar to ensure it stays above other elements.
Updated the background color to maintain visibility and improve the user experience.